### PR TITLE
feat: add draggable prop to enable horizontal scroll

### DIFF
--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -697,7 +697,13 @@ export const GanttChart = <T extends GanttChartData>({
         [getDateIndex, visibleRange, dayWidth]
     );
 
+    /**
+     * 타임라인 드래그 시작 핸들러
+     * @param {React.MouseEvent} e - 마우스 이벤트 객체
+     */
     const handleDragScrollStart = (e: React.MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
         // TaskBar 드래그 중이면 타임라인 드래그 금지
         if (isTaskBarDragging) return;
         if (e.button !== 0) return;
@@ -706,23 +712,39 @@ export const GanttChart = <T extends GanttChartData>({
         scrollStartLeft.current = containerRef.current?.scrollLeft ?? 0;
     };
 
+    /**
+     * 타임라인 드래그 중 이동 핸들러
+     * @param {MouseEvent} e - 마우스 이벤트 객체
+    */
     const handleDragScrollMove = useCallback((e: MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
         if (!isDragScrolling || !containerRef.current) return;
         const dx = e.clientX - dragStartX.current;
         containerRef.current.scrollLeft = scrollStartLeft.current - dx;
     }, [isDragScrolling]);
 
-    const handleDragScrollEnd = useCallback(() => {
+    /**
+     * 타임라인 드래그 종료 핸들러
+     * @param {MouseEvent} e - 마우스 이벤트 객체
+     */
+    const handleDragScrollEnd = useCallback((e: MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
         setIsDragScrolling(false);
     }, []);
 
+    /**
+     * 타임라인 드래그 이벤트 리스너 등록
+     */
     useEffect(() => {
-        if (isDragScrolling) {
-            window.addEventListener("mousemove", handleDragScrollMove);
-            window.addEventListener("mouseup", handleDragScrollEnd);
+        if (isDragScrolling && containerRef.current) {
+            const container = containerRef.current;
+            container.addEventListener("mousemove", handleDragScrollMove);
+            container.addEventListener("mouseup", handleDragScrollEnd);
             return () => {
-                window.removeEventListener("mousemove", handleDragScrollMove);
-                window.removeEventListener("mouseup", handleDragScrollEnd);
+                container.removeEventListener("mousemove", handleDragScrollMove);
+                container.removeEventListener("mouseup", handleDragScrollEnd);
             };
         }
     }, [isDragScrolling, handleDragScrollMove, handleDragScrollEnd]);

--- a/src/components/GanttChartType.ts
+++ b/src/components/GanttChartType.ts
@@ -98,6 +98,7 @@ export interface GanttChartProps<T extends GanttChartData>
     defaultGridSectionWidth?: number;
     defaultExpanded?: boolean;
     locale?: GanttChartLocale;
+    draggable?: boolean;
 }
 
 export interface GanttChartHandler<T extends GanttChartData> {

--- a/src/stories/GanttChart.stories.tsx
+++ b/src/stories/GanttChart.stories.tsx
@@ -200,7 +200,7 @@ export const Default: Story = {
         const { data, columns, ...rest } = args;
         return (
             <div className="w-screen h-screen">
-                <GanttChartContainer {...rest} data={data} columns={columns} />
+                <GanttChartContainer {...rest} data={data} columns={columns} draggable={true} />
             </div>
         );
     },


### PR DESCRIPTION
- GanttChart 컴포넌트에 draggable prop을 추가하여, 타임라인(가로 스크롤) 영역의 드래그 이동 기능을 켜거나 끌 수 있도록 했습니다.
- draggable이 true일 때, 사용자는 마우스 드래그로 타임라인을 가로로 이동할 수 있습니다.
- draggable이 false(기본값)이면, 드래그로 인한 가로 스크롤 이동 및 관련 커서(grab, grabbing) 스타일이 비활성화됩니다.
- 일정(TaskBar) 드래그와 타임라인 드래그가 서로 간섭하지 않도록 분리 처리되어 있습니다.